### PR TITLE
Fixed and simplified Async Operations

### DIFF
--- a/Source/Core/LimeAuthSession+Biometry.swift
+++ b/Source/Core/LimeAuthSession+Biometry.swift
@@ -26,14 +26,13 @@ public extension LimeAuthSession {
     /// Adds biometry factor to the session. The user has to provide a password to unlock sensitive information,
     /// required for the operation.
     public func addBiometryFactor(password: String, completion: @escaping (LimeAuthError?)->Void) -> Operation {
-        let operation = self.buildBlockOperation(execute: { (op) -> PA2OperationTask? in
-            return self.powerAuth.addBiometryFactor(password) { (error) in
-                op.finish(result: error == nil, error: .wrap(error))
+        
+        let operation = AsyncBlockOperation { _, markFinished in
+            self.powerAuth.addBiometryFactor(password) { error in
+                markFinished {
+                    completion(.wrap(error))
+                }
             }
-        }, completion: { (op, success: Bool?, error) in
-            completion(error)
-        }) { (op, cancellable) in
-            cancellable.cancel()
         }
         return self.addOperationToQueue(operation, serialized: true)
     }

--- a/Source/Core/LimeAuthSession+Password.swift
+++ b/Source/Core/LimeAuthSession+Password.swift
@@ -21,14 +21,12 @@ public extension LimeAuthSession {
     
     /// Function validates on server whether provided password is valid.
     public func validatePassword(password: String, completion: @escaping (LimeAuthError?)->Void) -> Operation {
-        let operation = self.buildBlockOperation(execute: { (op) -> PA2OperationTask? in
-            return self.powerAuth.validatePasswordCorrect(password) { (error) in
-                op.finish(result: error == nil, error: .wrap(error))
+        let operation = AsyncBlockOperation { _, markFinished in
+            self.powerAuth.validatePasswordCorrect(password) { error in
+                markFinished {
+                    completion(.wrap(error))
+                }
             }
-        }, completion: { (op, success: Bool?, error) in
-            completion(error)
-        }) { (op, cancellable) in
-            cancellable.cancel()
         }
         return self.addOperationToQueue(operation, serialized: true)
     }

--- a/Source/Core/LimeAuthSession+Queue.swift
+++ b/Source/Core/LimeAuthSession+Queue.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-internal protocol CompletableInSpecificQueue {
+public protocol CompletableInSpecificQueue {
     func assignCompletionDispatchQueue(_ queue: DispatchQueue?)
 }
 
@@ -30,13 +30,4 @@ public extension LimeAuthSession {
         queue.addOperation(operation)
         return operation
     }
-    
-    internal func buildBlockOperation<Result, Cancellable>(execute: @escaping (AsyncOperation<Result, Cancellable>)->Cancellable?,
-                                                           completion: @escaping (AsyncOperation<Result, Cancellable>, Result?, LimeAuthError?)->Void,
-                                                           cancel: ((AsyncOperation<Result, Cancellable>, Cancellable)->Void)? = nil) -> Operation {
-        return AsyncBlockOperation(execute, completion: completion, cancel: cancel)
-    }
-
 }
-
-

--- a/Source/Core/Operations/AsyncOperation.swift
+++ b/Source/Core/Operations/AsyncOperation.swift
@@ -20,7 +20,7 @@ import Foundation
 public class AsyncOperation: Operation, CompletableInSpecificQueue {
     
     override public var isAsynchronous: Bool { return true }
-    override public var isReady: Bool { return state == .isReady && dependencies.allSatisfy({ $0.isFinished }) }
+    override public var isReady: Bool { return state == .isReady && dependencies.contains(where: { !$0.isFinished }) == false } // TODO: when migarted to swift 4.2, use dependencies.allSatisfy({ $0.isFinished })
     override public var isExecuting: Bool { return state == .isExecuting }
     override public var isFinished: Bool { return state.done }
     override public var isCancelled: Bool { return state == .isCanceled }

--- a/Source/UI/Authentication/Process/AuthenticationUIOperationExecutor.swift
+++ b/Source/UI/Authentication/Process/AuthenticationUIOperationExecutor.swift
@@ -158,16 +158,13 @@ public class AuthenticationUIOperationExecutor: AuthenticationUIOperationExecuti
             //
         } else {
             // Wrap execution to operation serialized in session's serialization queue
-            let op = session.buildBlockOperation(execute: { (op) -> Void in
-                // Now execute that embedded operation
-                self.operation.execute(session: self.session, authentication: auth) { (result, error) in
-                    // Propagate result to the serialized operation
-                    op.finish(result: result, error: error)
+            let op = AsyncBlockOperation { _, markFinished in
+                
+                self.operation.execute(session: self.session, authentication: auth) { result, error in
+                    self.processExecutionResult(result: result, error: error, callback: callback)
+                    markFinished(nil)
                 }
-            }, completion: { (op, result, error) in
-                // ...and back to executor
-                self.processExecutionResult(result: result, error: error, callback: callback)
-            })
+            }
             synchronizedOperation = session.addOperationToQueue(op, serialized: true)
         }
     }


### PR DESCRIPTION
Issue #28 

Several points are addressed in this PR:

- Simplified `AsyncOperation` and `AsyncBlockOperation`
- Reworked `RealFetchOperation` to use "native" Operation dependency system
- `AsyncOperation` and `AsyncBlockOperation` are now public and more documented for app integration
- Fixed deadlock that could happen in fetch status operation 