### PR TITLE
Supporting vibration on older devices

### DIFF
--- a/LimeAuth.xcodeproj/project.pbxproj
+++ b/LimeAuth.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		DC1E500521A702580089B280 /* LimeAuthActionFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1E500421A702580089B280 /* LimeAuthActionFeedback.swift */; };
 		DC1E501421A81AE20089B280 /* failed.m4a in Resources */ = {isa = PBXBuildFile; fileRef = DC1E501221A81AE20089B280 /* failed.m4a */; };
 		DC1E501521A81AE20089B280 /* success.m4a in Resources */ = {isa = PBXBuildFile; fileRef = DC1E501321A81AE20089B280 /* success.m4a */; };
+		DC24A25021DFB5CC00C59002 /* VibrationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC24A24F21DFB5CB00C59002 /* VibrationEngine.swift */; };
+		DC42CA6D21DF697F00E13C23 /* UIDeviceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC42CA6C21DF697F00E13C23 /* UIDeviceExtensions.swift */; };
 		DC4763812153E04100187DF7 /* StylingExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4763802153E04100187DF7 /* StylingExtensions.swift */; };
 		DC519B5921A421B000768D8B /* LimeAuthPassphraseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC519B5821A421B000768D8B /* LimeAuthPassphraseValidator.swift */; };
 		DC519B5B21A47A0900768D8B /* PassphraseVerifying.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC519B5A21A47A0900768D8B /* PassphraseVerifying.swift */; };
@@ -219,6 +221,8 @@
 		DC1E500421A702580089B280 /* LimeAuthActionFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LimeAuthActionFeedback.swift; sourceTree = "<group>"; };
 		DC1E501221A81AE20089B280 /* failed.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = failed.m4a; sourceTree = "<group>"; };
 		DC1E501321A81AE20089B280 /* success.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = success.m4a; sourceTree = "<group>"; };
+		DC24A24F21DFB5CB00C59002 /* VibrationEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VibrationEngine.swift; sourceTree = "<group>"; };
+		DC42CA6C21DF697F00E13C23 /* UIDeviceExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceExtensions.swift; sourceTree = "<group>"; };
 		DC4763802153E04100187DF7 /* StylingExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylingExtensions.swift; sourceTree = "<group>"; };
 		DC519B5821A421B000768D8B /* LimeAuthPassphraseValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LimeAuthPassphraseValidator.swift; sourceTree = "<group>"; };
 		DC519B5A21A47A0900768D8B /* PassphraseVerifying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphraseVerifying.swift; sourceTree = "<group>"; };
@@ -676,6 +680,7 @@
 			isa = PBXGroup;
 			children = (
 				BFDB8CCD20516D4A0063C5EA /* PA2KeychainExtensions.swift */,
+				DC42CA6C21DF697F00E13C23 /* UIDeviceExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -736,6 +741,7 @@
 			children = (
 				DC1E500421A702580089B280 /* LimeAuthActionFeedback.swift */,
 				DCD62F6B21AD46B2006CB765 /* LimeAuthActionFeedbackAssets.swift */,
+				DC24A24F21DFB5CB00C59002 /* VibrationEngine.swift */,
 			);
 			path = ActionFeedback;
 			sourceTree = "<group>";
@@ -845,6 +851,7 @@
 				DC519B5B21A47A0900768D8B /* PassphraseVerifying.swift in Sources */,
 				BFDB8CD620516DE00063C5EA /* LimeAuthCredentialsProvider.swift in Sources */,
 				BFA49C2B20A48CA7000D82B6 /* ActivityIndicatorStyle.swift in Sources */,
+				DC24A25021DFB5CC00C59002 /* VibrationEngine.swift in Sources */,
 				BFBF77DE20AF2A4300139655 /* LimeAuthRestApiError.swift in Sources */,
 				BFAE06AC2059685C003485D7 /* NewCredentialsViewController.swift in Sources */,
 				BF496437205997A6002560A8 /* DefaultAuthenticationResourcesProvider.swift in Sources */,
@@ -864,6 +871,7 @@
 				BF68809520480FC800351112 /* LimeAuthActivationUI+DefaultResources.swift in Sources */,
 				BFDB8CCE20516D4B0063C5EA /* PA2KeychainExtensions.swift in Sources */,
 				BF565FAC2047423600B9C897 /* EnableBiometryViewController.swift in Sources */,
+				DC42CA6D21DF697F00E13C23 /* UIDeviceExtensions.swift in Sources */,
 				BF565F92204728CC00B9C897 /* KeysExchangeViewController.swift in Sources */,
 				BF6134322044765E00164496 /* QRCodeScanner.swift in Sources */,
 				BF565F94204728DE00B9C897 /* KeysExchangeRouter.swift in Sources */,

--- a/Source/Core/Extensions/UIDeviceExtensions.swift
+++ b/Source/Core/Extensions/UIDeviceExtensions.swift
@@ -1,0 +1,99 @@
+//
+// Copyright 2019 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+
+import UIKit
+
+public enum SystemVariant {
+    case iPhone(_ gen: Int, _ version: Int)
+    case iPad(_ gen: Int, _ version: Int)
+    case iPod(_ gen: Int, _ version: Int)
+    case watch(_ gen: Int, _ version: Int)
+    case simulator
+    case unknown
+}
+
+public extension UIDevice {
+    
+    /// Parses type and version of the system
+    public static var deviceVersion: SystemVariant = {
+        
+        var sysinfo = utsname()
+        uname(&sysinfo)
+        
+        guard let sysname = String(bytes: Data(bytes: &sysinfo.machine, count: Int(_SYS_NAMELEN)), encoding: .ascii)?.trimmingCharacters(in: .controlCharacters).lowercased() else {
+            D.error("Cannot parse system name")
+            return .unknown
+        }
+        
+        if sysname == "i386" || sysname == "x86_64" {
+            return .simulator
+        }
+        
+        do {
+            let regexp = try NSRegularExpression(pattern: "([a-z]*)([0-9]*),([0-9]*)")
+            let matches = regexp.matches(in: sysname, options: [], range: NSRange(location: 0, length: sysname.count))
+            
+            guard matches.count == 1 && matches[0].numberOfRanges == 4 else {
+                D.error("unknown system format")
+                return .unknown
+            }
+            
+            let nsSysname = (sysname as NSString)
+            let variant = nsSysname.substring(with: matches[0].range(at: 1))
+            guard
+                let gen = Int(nsSysname.substring(with: matches[0].range(at: 2))),
+                let version = Int(nsSysname.substring(with: matches[0].range(at: 3))) else {
+                    D.error("Cannot parse system version")
+                    return .unknown
+            }
+            
+            switch variant {
+            case "iphone": return .iPhone(gen, version)
+            case "ipod": return .iPod(gen, version)
+            case "ipad": return .iPad(gen, version)
+            case "watch": return .watch(gen, version)
+            default:
+                D.error("unkwnown version variant")
+                return .unknown
+            }
+            
+            
+        } catch {
+            D.error("Cannot prepare regular expression when parsing system name")
+            return .unknown
+        }
+    }()
+    
+    /// If device has 1st gen haptic engine (eg iP 6s)
+    public static var hasTapticEngine: Bool = {
+        
+        guard case .iPhone(let gen, let version) = deviceVersion else {
+            return false
+        }
+        
+        return gen >= 9 || (gen == 8 && version <= 2) // present in 9th gen and later, in 8th gen present only in 6s & 6s+ (version 1 & 2)
+    }()
+    
+    /// If device has 2nd gen haptic engine (eg iP 7 or 8)
+    public static var hasHapticEngine: Bool = {
+        
+        guard case .iPhone(let gen, _) = deviceVersion else {
+            return false
+        }
+        
+        return gen >= 9 // 9 gen devices are ip7 and later
+    }()
+}

--- a/Source/UI/Common/ActionFeedback/VibrationEngine.swift
+++ b/Source/UI/Common/ActionFeedback/VibrationEngine.swift
@@ -1,0 +1,186 @@
+//
+// Copyright 2019 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+
+import Foundation
+import AudioToolbox
+
+// "Abstract" class for vibration
+class VibrationEngine {
+    
+    // use static create() method instead
+    fileprivate init() {
+        
+    }
+    
+    /// Will vibrate given type.
+    /// Availability and type of vibration is based on the device and not all types are available on older devices
+    func play(_ what: LimeAuthHapticType) {
+        // to override
+    }
+    
+    /// Puts engine to sleep
+    func sleep() {
+        // to override
+    }
+    
+    /// Wakes up the engine to get imidiate responses when play is called
+    func prepare() {
+        // to override
+    }
+    
+    /// Factory function
+    static func create() -> VibrationEngine {
+        
+        if UIDevice.hasHapticEngine {
+            return HapticEngine()
+        }
+        
+        if UIDevice.hasTapticEngine {
+            return TapticEngine()
+        }
+        
+        return DefaultEngine()
+    }
+}
+
+/// Default vibrations that are available in every iphone
+fileprivate class DefaultEngine: VibrationEngine {
+    
+    public enum Vibration: UInt32 {
+        /// Basic 1-second vibration
+        case `default` = 4095
+        /// Two short consecutive vibrations
+        case alert = 1011
+    }
+    
+    override func play(_ what: LimeAuthHapticType) {
+        
+        switch what {
+        case .notification(let notificationType):
+            switch notificationType {
+            case .success: vibrate(.default)
+            case .warning: vibrate(.alert)
+            case .error: vibrate(.alert)
+            }
+        default:
+            // dont do anything
+            break
+        }
+    }
+    
+    private func vibrate(_ what: Vibration) {
+        AudioServicesPlaySystemSound(what.rawValue)
+    }
+}
+
+// Haptic engine version 1 (for 6S and 6S+)
+fileprivate class TapticEngine: VibrationEngine {
+    
+    private enum TapticPattern: UInt32 {
+        /// Weak boom
+        case peek = 1519
+        /// Strong boom
+        case pop = 1520
+        /// Three sequential weak booms
+        case cancelled = 1521
+        /// Weak boom then strong boom
+        case tryAgain = 1102
+        /// Three sequential strong booms
+        case failed = 1107
+    }
+    
+    override func play(_ what: LimeAuthHapticType) {
+        
+        switch what {
+        case .impact(let strength):
+            switch strength {
+            case .light: vibrate(.peek)
+            case .medium: vibrate(.peek)
+            case .heavy: vibrate(.pop)
+            }
+        case .notification(let notificationType):
+            switch notificationType {
+            case .success: vibrate(.tryAgain)
+            case .warning: vibrate(.failed)
+            case .error: vibrate(.failed)
+            }
+        case .selection:
+            vibrate(.peek)
+        }
+    }
+    
+    private func vibrate(_ what: TapticPattern) {
+        AudioServicesPlaySystemSound(what.rawValue)
+    }
+}
+
+// Haptic engine version 2 (for 7 and later)
+fileprivate class HapticEngine: VibrationEngine {
+    
+    private var impactLight: UIImpactFeedbackGenerator?
+    private var impactMedium: UIImpactFeedbackGenerator?
+    private var impactHeavy: UIImpactFeedbackGenerator?
+    private var notification: UINotificationFeedbackGenerator?
+    private var selection: UISelectionFeedbackGenerator?
+    private var generators: [UIFeedbackGenerator?] { return [impactLight, impactMedium, impactHeavy, notification, selection] }
+    
+    override func play(_ what: LimeAuthHapticType) {
+        
+        if impactLight == nil {
+            wakeUp()
+        }
+        
+        switch what {
+        case .impact(let strength):
+            switch strength {
+            case .light: impactLight?.impactOccurred()
+            case .medium: impactMedium?.impactOccurred()
+            case .heavy: impactHeavy?.impactOccurred()
+            }
+        case .notification(let notificationType):
+            switch notificationType {
+            case .success: notification?.notificationOccurred(.success)
+            case .warning: notification?.notificationOccurred(.warning)
+            case .error: notification?.notificationOccurred(.error)
+            }
+        case .selection:
+            selection?.selectionChanged()
+        }
+    }
+    
+    override func sleep() {
+        impactLight = nil
+        impactMedium = nil
+        impactHeavy = nil
+        notification = nil
+        selection = nil
+    }
+    
+    override func prepare() {
+        if impactLight == nil {
+            wakeUp()
+        }
+        generators.forEach { $0?.prepare() }
+    }
+    
+    private func wakeUp() {
+        impactLight = UIImpactFeedbackGenerator(style: .light)
+        impactMedium = UIImpactFeedbackGenerator(style: .medium)
+        impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
+        notification = UINotificationFeedbackGenerator()
+        selection = UISelectionFeedbackGenerator()
+    }
+}


### PR DESCRIPTION
#69 

This PR creates 3 separated "vibration schemes"

1. For iPhone 7 and newer, it uses new class `HapticEngine` that uses system "haptic API"
2. For iPhone 6S, it uses `TapticEngine` class that leverages 3D touch "vibration API"
3. For other, it defaults to simple vibration present in all iPhones (it enables only "success" and "fail" scenarios)