### PR TITLE
ActionFeedback: option to disable non-taptic vibrations

### DIFF
--- a/Source/UI/Common/ActionFeedback/LimeAuthActionFeedback.swift
+++ b/Source/UI/Common/ActionFeedback/LimeAuthActionFeedback.swift
@@ -19,7 +19,6 @@ import AudioToolbox
 import AVFoundation
 
 /// Class that plays haptic and audio feedback for easier use.
-/// For simplicity and configuration of default LimeAuth UI components use `shared` singleton.
 public class LimeAuthActionFeedback: NSObject {
     
     /// When false, haptic(..) calls will be ignored
@@ -27,17 +26,25 @@ public class LimeAuthActionFeedback: NSObject {
     /// When false, audio(..) calls will be ignored
     public var audioEnabled = true
     
+    /// When false (default value), no vibrations will be played on devices without taptic or haptic engine (phones like 6 or SE).
+    public var allowFallbackVibrations = false {
+        didSet {
+            vibrationEngine = VibrationEngine.create(allowNontapticPhones: allowFallbackVibrations)
+        }
+    }
+    
     /// Success sound in predefined success scene. Default value available only when LimeAuth/UIResources_Sounds pod is used.
     public var successSound: URL? = Bundle(for: LimeAuthActionFeedback.self).url(forResource: "success", withExtension: "m4a")
     /// Fail sound in predefined success scene. Default value available only when LimeAuth/UIResources_Sounds pod is used.
     public var failSound: URL? = Bundle(for: LimeAuthActionFeedback.self).url(forResource: "failed", withExtension: "m4a")
     
-    private let vibrationEngine = VibrationEngine.create()
+    private var vibrationEngine: VibrationEngine
     
     // player that will play custom sounds
     private lazy var player = AVQueuePlayer()
     
-    public override init () {
+    public override init() {
+        vibrationEngine = VibrationEngine.create(allowNontapticPhones: allowFallbackVibrations)
         super.init()
     }
     

--- a/Source/UI/Common/ActionFeedback/VibrationEngine.swift
+++ b/Source/UI/Common/ActionFeedback/VibrationEngine.swift
@@ -17,7 +17,7 @@
 import Foundation
 import AudioToolbox
 
-// "Abstract" class for vibration
+// Default "silent" engine
 class VibrationEngine {
     
     // use static create() method instead
@@ -42,7 +42,7 @@ class VibrationEngine {
     }
     
     /// Factory function
-    static func create() -> VibrationEngine {
+    static func create(allowNontapticPhones: Bool) -> VibrationEngine {
         
         if UIDevice.hasHapticEngine {
             return HapticEngine()
@@ -52,7 +52,7 @@ class VibrationEngine {
             return TapticEngine()
         }
         
-        return DefaultEngine()
+        return allowNontapticPhones ? DefaultEngine() : VibrationEngine()
     }
 }
 


### PR DESCRIPTION
Fixed #71 

Vibrations for non-taptic phones (like 5S) is not opt-in feature instead of mandatory (which can be annoying).