### PR TITLE
Forcing fonts on Passcode VC

### DIFF
--- a/Source/UI/Authentication/Scenes/CreateFixedPasscode/CreateFixedPasscodeViewController.swift
+++ b/Source/UI/Authentication/Scenes/CreateFixedPasscode/CreateFixedPasscodeViewController.swift
@@ -313,7 +313,9 @@ open class CreateFixedPasscodeViewController: LimeAuthUIBaseViewController, Crea
         prompt1Label?.textColor = theme.common.promptTextColor
         prompt2Label?.textColor = theme.common.promptTextColor
         password1Label?.textColor = theme.common.passwordTextColor
+        password1Label.font = UIFont.systemFont(ofSize: 40)
         password2Label?.textColor = theme.common.passwordTextColor
+        password2Label.font = UIFont.systemFont(ofSize: 40)
         error1Label?.textColor = theme.common.highlightedTextColor
         (activityIndicator as? CheckmarkWithActivityView)?.applyIndicatorStyle(theme.styleForCheckmarkWithActivity)
         changeComplexityButton?.applyButtonStyle(theme.buttons.keyboardAuxiliary)

--- a/Source/UI/Authentication/Scenes/CreatePasscode/CreatePasscodeViewController.swift
+++ b/Source/UI/Authentication/Scenes/CreatePasscode/CreatePasscodeViewController.swift
@@ -322,7 +322,9 @@ open class CreatePasscodeViewController: LimeAuthUIBaseViewController, CreateAnd
         prompt1Label?.textColor = theme.common.promptTextColor
         prompt2Label?.textColor = theme.common.promptTextColor
         password1Label?.textColor = theme.common.passwordTextColor
+        password1Label?.font = UIFont.systemFont(ofSize: 22)
         password2Label?.textColor = theme.common.passwordTextColor
+        password2Label?.font = UIFont.systemFont(ofSize: 22)
         error1Label?.textColor = theme.common.highlightedTextColor
         confirm1Button?.applyButtonStyle(theme.buttons.ok)
         confirm2Button?.applyButtonStyle(theme.buttons.ok)

--- a/Source/UI/Authentication/Scenes/CreatePassword/CreatePasswordViewController.swift
+++ b/Source/UI/Authentication/Scenes/CreatePassword/CreatePasswordViewController.swift
@@ -279,7 +279,9 @@ open class CreatePasswordViewController: LimeAuthUIBaseViewController, CreateAnd
         prompt1Label?.textColor = theme.common.promptTextColor
         prompt2Label?.textColor = theme.common.promptTextColor
         password1TextField?.applyTextFieldStyle(theme.common.passwordTextField)
+        password1TextField?.font = UIFont.systemFont(ofSize: 17)
         password2TextField?.applyTextFieldStyle(theme.common.passwordTextField)
+        password2TextField?.font = UIFont.systemFont(ofSize: 17)
         error1Label?.textColor = theme.common.highlightedTextColor
         confirm1Button?.applyButtonStyle(theme.buttons.ok)
         confirm2Button?.applyButtonStyle(theme.buttons.ok)

--- a/Source/UI/Authentication/Scenes/EnterFixedPasscode/EnterFixedPasscodeViewController.swift
+++ b/Source/UI/Authentication/Scenes/EnterFixedPasscode/EnterFixedPasscodeViewController.swift
@@ -346,6 +346,7 @@ open class EnterFixedPasscodeViewController: LimeAuthUIBaseViewController, Enter
         promptLabel?.textColor = theme.common.promptTextColor
         attemptsLabel?.textColor = theme.common.highlightedTextColor
         fixedPinLabel?.textColor = theme.common.passwordTextColor
+        fixedPinLabel.font = UIFont.systemFont(ofSize: 40)
         
         // KB delegate
         pinKeyboard?.delegate = self

--- a/Source/UI/Authentication/Scenes/EnterPasscode/EnterPasscodeViewController.swift
+++ b/Source/UI/Authentication/Scenes/EnterPasscode/EnterPasscodeViewController.swift
@@ -360,6 +360,7 @@ open class EnterPasscodeViewController: LimeAuthUIBaseViewController, EnterPassw
         promptLabel?.textColor = theme.common.promptTextColor
         attemptsLabel?.textColor = theme.common.highlightedTextColor
         variablePinLabel?.textColor = theme.common.passwordTextColor
+        variablePinLabel?.font = UIFont.systemFont(ofSize: 22)
         roundCornersView?.applyLayerStyle(theme.layerStyleFromAuthenticationCommon)
         
         // KB delegate

--- a/Source/UI/Authentication/Scenes/EnterPassword/EnterPasswordViewController.swift
+++ b/Source/UI/Authentication/Scenes/EnterPassword/EnterPasswordViewController.swift
@@ -347,6 +347,7 @@ open class EnterPasswordViewController: LimeAuthUIBaseViewController, EnterPassw
         
         configureBackground(image: theme.common.backgroundImage, color: theme.common.backgroundColor)
         passwordTextField?.applyTextFieldStyle(theme.common.passwordTextField)
+        passwordTextField?.font = UIFont.systemFont(ofSize: 17)
         closeErrorButton?.applyButtonStyle(theme.buttons.dismissError)
         confirmPasswordButton?.applyButtonStyle(theme.buttons.ok)
         (activityIndicator as? CheckmarkWithActivityView)?.applyIndicatorStyle(theme.styleForCheckmarkWithActivity)


### PR DESCRIPTION
Forcing size and system fonts on Passcode View Controllers to avoid custom fonts.