### PR TITLE
Removed spinner on recovery screen

### DIFF
--- a/Source/UI/Recovery/Scenes/RecoveryViewController.swift
+++ b/Source/UI/Recovery/Scenes/RecoveryViewController.swift
@@ -29,7 +29,6 @@ public class RecoveryViewController: LimeAuthUIBaseViewController, RecoveryViewD
     
     var showCountdownDelay = true
     
-    private var isRecoveryLoading = false
     private var uiProvider: RecoveryUIProvider!
     private var finishedCallback: FinishedCallback!
     private var displayContext: DisplayContext!
@@ -37,7 +36,6 @@ public class RecoveryViewController: LimeAuthUIBaseViewController, RecoveryViewD
     
     @IBOutlet private weak var displayView: RecoveryDisplayView!
     @IBOutlet private weak var titleLabel: UILabel!
-    @IBOutlet private weak var loadingIndicator: UIActivityIndicatorView!
     
     public func setup(withData data: LimeAuthRecoveryData, uiProvider: RecoveryUIProvider, context: DisplayContext, finishedCallback: @escaping FinishedCallback) {
         guard self.uiProvider == nil else {

--- a/Source/UIResources/Recovery/Recovery.storyboard
+++ b/Source/UIResources/Recovery/Recovery.storyboard
@@ -18,9 +18,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="FGn-Xe-Kcu">
-                                <rect key="frame" x="197" y="438" width="20" height="20"/>
-                            </activityIndicatorView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z6V-jG-9xc" customClass="RecoveryDisplayView" customModule="LimeAuth" customModuleProvider="target">
                                 <rect key="frame" x="20" y="117" width="374" height="725"/>
                                 <subviews>
@@ -148,16 +145,13 @@
                             <constraint firstAttribute="trailingMargin" secondItem="Z6V-jG-9xc" secondAttribute="trailing" id="LxG-5m-4GY"/>
                             <constraint firstItem="mHL-Xs-Pkq" firstAttribute="bottom" secondItem="Z6V-jG-9xc" secondAttribute="bottom" constant="20" id="cpN-Dq-dJS"/>
                             <constraint firstAttribute="trailing" secondItem="ZwS-og-32F" secondAttribute="trailing" id="hpb-cR-v2Y"/>
-                            <constraint firstItem="FGn-Xe-Kcu" firstAttribute="centerY" secondItem="2zM-KU-EeL" secondAttribute="centerY" id="qJp-Vh-t3S"/>
                             <constraint firstItem="Z6V-jG-9xc" firstAttribute="top" secondItem="ZwS-og-32F" secondAttribute="bottom" constant="14" id="qz6-Ah-hak"/>
-                            <constraint firstItem="FGn-Xe-Kcu" firstAttribute="centerX" secondItem="2zM-KU-EeL" secondAttribute="centerX" id="viJ-br-6kP"/>
                             <constraint firstItem="Z6V-jG-9xc" firstAttribute="leading" secondItem="2zM-KU-EeL" secondAttribute="leadingMargin" id="xAM-YF-3Rk"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="mHL-Xs-Pkq"/>
                     </view>
                     <connections>
                         <outlet property="displayView" destination="Z6V-jG-9xc" id="TyA-jd-MKt"/>
-                        <outlet property="loadingIndicator" destination="FGn-Xe-Kcu" id="Rwx-ka-KJf"/>
                         <outlet property="titleLabel" destination="ZwS-og-32F" id="Bzh-qK-JuA"/>
                     </connections>
                 </viewController>


### PR DESCRIPTION
Removed spinner on recovery screen that is no longer needed.

_Sidenote: no need to create new versions, recovery feature is still being tested and updated (especially from the design point of view), there likely will be more PR._