### PR TITLE
Removed gray camera background

### DIFF
--- a/Source/UI/Activation/Scenes/ScanCode/ScanActivationCodeViewController.swift
+++ b/Source/UI/Activation/Scenes/ScanCode/ScanActivationCodeViewController.swift
@@ -130,7 +130,9 @@ open class ScanActivationCodeViewController: LimeAuthUIBaseViewController, Activ
     }
     
     open func qrCodeProviderCameraPreview(_ provider: QRCodeProvider, forSession session: AVCaptureSession?) -> UIView? {
-        return self.view
+        // to avoid gray temporary background until the camera "kicks in"
+        view.backgroundColor = uiDataProvider.uiTheme.common.backgroundColor
+        return view
     }
     
     


### PR DESCRIPTION
This fixes #122.

When the camera preview is starting, the gray background is displayed. This PR is changing that do "default provided background".